### PR TITLE
add password ps1 using net

### DIFF
--- a/blue-team/windows/password_net.ps1
+++ b/blue-team/windows/password_net.ps1
@@ -1,0 +1,14 @@
+# password scripting using net since Get-LocalUser is PS 5.1+
+
+$users = (-Split ((Out-String -InputObject (net user)) -replace "The command completed successfully\.","" -replace "-*","" -replace "User accounts .*",""))
+$template = Read-Host -Prompt "Template (prefix)"
+$output = "12.csv"
+
+Clear-Content $output
+foreach ($user in $users){
+	# Write-Output $user
+	Add-Content $output $user","$template$user
+	net user $user $template$user
+}
+Get-Content $output
+notepad.exe $output


### PR DESCRIPTION
cuz get localuser is only available on PS 5.1+ but sometimes you have an earlier version of PS so it doesnt work ;w;